### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/paniclock/paniclock/security/code-scanning/1](https://github.com/paniclock/paniclock/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions:` block that grants the minimal set of privileges needed to complete the workflow. For a simple build job that only checks out code and runs local build commands, this is usually `contents: read` at either the workflow root (applies to all jobs) or the job level.

For this specific workflow, the safest and least intrusive fix is to add a workflow-level `permissions:` block after the `name:` line and before the `on:` section in `.github/workflows/build.yml`. The job only checks out the code (`actions/checkout@v4`) and runs `xcode-select` and `xcodebuild`; no step pushes commits, creates releases, or interacts with other resources that would require write access. Therefore, `permissions: contents: read` is sufficient and does not change existing functionality, while ensuring the `GITHUB_TOKEN` is restricted even if repository/organization defaults are broader.

Concretely, edit `.github/workflows/build.yml` so that:

- Lines 1–2 remain as they are.
- Insert a new `permissions:` block starting at new line 3:

```yaml
permissions:
  contents: read
```

- The existing `on:` block will then move down and continue unchanged.

No additional imports or methods are required since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
