### PR TITLE
feat: enable biometrics disable on clamshell sleep

### DIFF
--- a/PanicLock.xcodeproj/project.pbxproj
+++ b/PanicLock.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		A10000010000000000000011 /* XPCProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000007 /* XPCProtocol.swift */; };
 		A10000010000000000000012 /* LaunchAtLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000012 /* LaunchAtLoginManager.swift */; };
 		A10000010000000000000013 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000013 /* AboutView.swift */; };
+		A10000010000000000000014 /* LockState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000014 /* LockState.swift */; };
+		A10000010000000000000015 /* PowerMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000015 /* PowerMonitor.swift */; };
+		A10000010000000000000016 /* ScreenUnlockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000016 /* ScreenUnlockObserver.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +48,9 @@
 		A10000020000000000000010 /* HelperTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperTool.swift; sourceTree = "<group>"; };
 		A10000020000000000000012 /* LaunchAtLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginManager.swift; sourceTree = "<group>"; };
 		A10000020000000000000013 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
+		A10000020000000000000014 /* LockState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockState.swift; sourceTree = "<group>"; };
+		A10000020000000000000015 /* PowerMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerMonitor.swift; sourceTree = "<group>"; };
+		A10000020000000000000016 /* ScreenUnlockObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenUnlockObserver.swift; sourceTree = "<group>"; };
 		A10000030000000000000001 /* PanicLock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PanicLock.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000030000000000000002 /* com.paniclock.helper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = com.paniclock.helper; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000040000000000000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -93,6 +99,9 @@
 				A10000020000000000000006 /* SettingsManager.swift */,
 				A10000020000000000000012 /* LaunchAtLoginManager.swift */,
 				A10000020000000000000013 /* AboutView.swift */,
+				A10000020000000000000014 /* LockState.swift */,
+				A10000020000000000000015 /* PowerMonitor.swift */,
+				A10000020000000000000016 /* ScreenUnlockObserver.swift */,
 				A10000020000000000000008 /* Assets.xcassets */,
 				A10000040000000000000001 /* Info.plist */,
 				A10000040000000000000002 /* PanicLock.entitlements */,
@@ -252,6 +261,9 @@
 				A10000010000000000000007 /* XPCProtocol.swift in Sources */,
 				A10000010000000000000012 /* LaunchAtLoginManager.swift in Sources */,
 				A10000010000000000000013 /* AboutView.swift in Sources */,
+				A10000010000000000000014 /* LockState.swift in Sources */,
+				A10000010000000000000015 /* PowerMonitor.swift in Sources */,
+				A10000010000000000000016 /* ScreenUnlockObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PanicLock/LockState.swift
+++ b/PanicLock/LockState.swift
@@ -1,0 +1,43 @@
+import Combine
+
+enum LockEvent {
+  case systemWillSleep
+  case systemDidWake
+  case screenUnlocked
+}
+
+enum LockState {
+  case idle
+  case locking
+  case locked
+  case waitingForUnlock
+  case unlocking
+}
+
+final class LockStateMachine: ObservableObject {
+  @Published private(set) var state = LockState.idle
+  var isEnabled = false
+
+  func handle(_ event: LockEvent) {
+    switch (state, event) {
+    case (.idle, .systemWillSleep) where isEnabled:
+      state = .locking
+    case (.locked, .systemDidWake):
+      state = .waitingForUnlock
+    case (.waitingForUnlock, .screenUnlocked):
+      state = .unlocking
+    default:
+      break
+    }
+  }
+
+  func completeLocking() {
+    guard state == .locking else { return }
+    state = .locked
+  }
+
+  func completeUnlocking() {
+    guard state == .unlocking else { return }
+    state = .idle
+  }
+}

--- a/PanicLock/PanicLockApp.swift
+++ b/PanicLock/PanicLockApp.swift
@@ -1,9 +1,10 @@
 import SwiftUI
+import Combine
 
 @main
 struct PanicLockApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
     var body: some Scene {
         Settings {
             PreferencesView()
@@ -14,29 +15,114 @@ struct PanicLockApp: App {
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var menuBarController: MenuBarController?
     private var settingsWindowController: NSWindowController?
-    
+    private let powerMonitor = PowerMonitor()
+    private let screenUnlockObserver = ScreenUnlockObserver()
+    private let stateMachine = LockStateMachine()
+    private var cancellables = Set<AnyCancellable>()
+    private var pendingSleepToken: PowerMonitor.SleepToken?
+    private var sleepTimeoutWork: DispatchWorkItem?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Initialize menu bar controller
         menuBarController = MenuBarController()
-        
+
         // Setup global keyboard shortcut
         KeyboardShortcutManager.shared.setupGlobalShortcut()
-        
+
         // Sync launch-at-login: if user setting is enabled but system registration is not, register now
         // This handles first launch (default is true) and cases where system state was reset
         if SettingsManager.shared.launchAtLogin && !LaunchAtLoginManager.shared.isEnabled {
             LaunchAtLoginManager.shared.setLaunchAtLogin(enabled: true)
         }
-        
+
         // Install helper if needed
         PanicLockManager.shared.installHelperIfNeeded()
+
+        // Setup lock-on-close
+        setupLockOnClose()
     }
-    
+
     func applicationWillTerminate(_ notification: Notification) {
         KeyboardShortcutManager.shared.removeGlobalShortcut()
     }
-    
+
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
         return true
+    }
+
+    // MARK: - Lock on Close
+
+    private func setupLockOnClose() {
+        SettingsManager.shared.$lockOnClose
+            .sink { [weak self] enabled in
+                self?.stateMachine.isEnabled = enabled
+            }
+            .store(in: &cancellables)
+
+        powerMonitor.onSleepRequest = { [weak self] token in
+            guard let self else { return }
+            if token.isClamshellSleep && stateMachine.isEnabled {
+                storeSleepToken(token)
+                stateMachine.handle(.systemWillSleep)
+                if stateMachine.state != .locking {
+                    // State machine didn't transition — don't hold system sleep.
+                    acknowledgePendingSleep()
+                }
+            } else {
+                powerMonitor.acknowledgeSleep(token)
+            }
+        }
+
+        powerMonitor.onWake = { [weak self] in
+            self?.stateMachine.handle(.systemDidWake)
+        }
+
+        screenUnlockObserver.onScreenUnlocked = { [weak self] in
+            self?.stateMachine.handle(.screenUnlocked)
+        }
+
+        stateMachine.$state
+            .removeDuplicates()
+            .sink { [weak self] newState in
+                self?.handleStateChange(newState)
+            }
+            .store(in: &cancellables)
+
+        powerMonitor.start()
+        screenUnlockObserver.start()
+    }
+
+    private func handleStateChange(_ state: LockState) {
+        switch state {
+        case .locking:
+            PanicLockManager.shared.executePanicLock()
+            stateMachine.completeLocking()
+            acknowledgePendingSleep()
+        case .unlocking:
+            stateMachine.completeUnlocking()
+        case .idle, .waitingForUnlock, .locked:
+            break
+        }
+    }
+
+    private func storeSleepToken(_ token: PowerMonitor.SleepToken) {
+        acknowledgePendingSleep()
+        pendingSleepToken = token
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, pendingSleepToken != nil else { return }
+            print("Sleep acknowledgment timeout — force acknowledging")
+            acknowledgePendingSleep()
+        }
+        sleepTimeoutWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 25, execute: work)
+    }
+
+    private func acknowledgePendingSleep() {
+        if let token = pendingSleepToken {
+            powerMonitor.acknowledgeSleep(token)
+            pendingSleepToken = nil
+        }
+        sleepTimeoutWork?.cancel()
+        sleepTimeoutWork = nil
     }
 }

--- a/PanicLock/PowerMonitor.swift
+++ b/PanicLock/PowerMonitor.swift
@@ -1,0 +1,129 @@
+import Foundation
+import IOKit
+import IOKit.pwr_mgt
+
+// IOKit C macros not bridged to Swift
+private let messageSystemWillSleep: UInt32 = 0xe000_0280
+private let messageSystemHasPoweredOn: UInt32 = 0xe000_0300
+private let messageCanSystemSleep: UInt32 = 0xe000_0240
+
+final class PowerMonitor {
+
+  deinit {
+    stop()
+    }
+
+  struct SleepToken {
+    let rootPort: io_connect_t
+    let messageArgument: Int
+    let isClamshellSleep: Bool
+  }
+
+  var onWake: (() -> Void)?
+
+  /// Caller must call `acknowledgeSleep(_:)` within 30s.
+  var onSleepRequest: ((SleepToken) -> Void)?
+
+  func start() {
+    // C callback — cannot capture context, uses refcon pointer instead
+    let callback: IOServiceInterestCallback = { refcon, _, messageType, messageArgument in
+      guard let refcon else { return }
+      let monitor = Unmanaged<PowerMonitor>.fromOpaque(refcon).takeUnretainedValue()
+      monitor.handleSleepWake(messageType: messageType, argument: messageArgument)
+    }
+
+    let refcon = Unmanaged.passUnretained(self).toOpaque()
+    rootPort = IORegisterForSystemPower(
+      refcon,
+      &notificationPort,
+      callback,
+      &notifierObject,
+    )
+
+    guard rootPort != 0, let port = notificationPort else {
+      print("PowerMonitor: Failed to register for system power notifications")
+      return
+    }
+
+    CFRunLoopAddSource(
+      CFRunLoopGetMain(),
+      IONotificationPortGetRunLoopSource(port).takeUnretainedValue(),
+      .defaultMode,
+    )
+  }
+
+  func stop() {
+    if notifierObject != 0 {
+      IODeregisterForSystemPower(&notifierObject)
+      notifierObject = 0
+    }
+    if let port = notificationPort {
+      CFRunLoopRemoveSource(
+        CFRunLoopGetMain(),
+        IONotificationPortGetRunLoopSource(port).takeUnretainedValue(),
+        .defaultMode,
+      )
+      IONotificationPortDestroy(port)
+      notificationPort = nil
+    }
+    rootPort = 0
+  }
+
+  func acknowledgeSleep(_ token: SleepToken) {
+    IOAllowPowerChange(token.rootPort, token.messageArgument)
+  }
+
+  private var rootPort: io_connect_t = 0
+  private var notificationPort: IONotificationPortRef?
+  private var notifierObject: io_object_t = 0
+
+  /// Lid Closed & No External Display
+  private static func checkClamshellSleep() -> Bool {
+    let service = IOServiceGetMatchingService(
+      kIOMainPortDefault,
+      IOServiceMatching("IOPMrootDomain"),
+    )
+    defer { IOObjectRelease(service) }
+    guard service != 0 else { return false }
+
+    func boolProperty(_ key: String) -> Bool {
+      IORegistryEntryCreateCFProperty(service, key as CFString, kCFAllocatorDefault, 0)
+        .map { ($0.takeRetainedValue() as? Bool) ?? false } ?? false
+    }
+
+    return boolProperty("AppleClamshellState") && boolProperty("AppleClamshellCausesSleep")
+  }
+
+  private func handleSleepWake(messageType: UInt32, argument: UnsafeMutableRawPointer?) {
+    switch messageType {
+    case messageSystemWillSleep:
+      let clamshell = Self.checkClamshellSleep()
+      let token = SleepToken(
+        rootPort: rootPort,
+        messageArgument: argument.map { Int(bitPattern: $0) } ?? 0,
+        isClamshellSleep: clamshell,
+      )
+      DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        if let onSleepRequest {
+          onSleepRequest(token)
+        } else {
+          acknowledgeSleep(token)
+        }
+      }
+
+    case messageSystemHasPoweredOn:
+      DispatchQueue.main.async { [weak self] in
+        self?.onWake?()
+      }
+
+    case messageCanSystemSleep:
+      if let argument {
+        IOAllowPowerChange(rootPort, Int(bitPattern: argument))
+      }
+
+    default:
+      break
+    }
+  }
+}

--- a/PanicLock/PreferencesView.swift
+++ b/PanicLock/PreferencesView.swift
@@ -44,8 +44,10 @@ struct PreferencesView: View {
                     .onChange(of: settings.launchAtLogin) { _, newValue in
                         LaunchAtLoginManager.shared.setLaunchAtLogin(enabled: newValue)
                     }
-                
+
                 Toggle("Play Confirmation Sound", isOn: $settings.confirmationSound)
+
+                Toggle("Lock on Close", isOn: $settings.lockOnClose)
             }
             
             Section("About") {

--- a/PanicLock/ScreenUnlockObserver.swift
+++ b/PanicLock/ScreenUnlockObserver.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+final class ScreenUnlockObserver {
+
+  deinit {
+    stop()
+  }
+
+  var onScreenUnlocked: (() -> Void)?
+
+  func start() {
+    guard observerToken == nil else { return }
+    observerToken = DistributedNotificationCenter.default().addObserver(
+      forName: NSNotification.Name("com.apple.screenIsUnlocked"),
+      object: nil,
+      queue: .main,
+    ) { [weak self] _ in
+      self?.onScreenUnlocked?()
+    }
+  }
+
+  func stop() {
+    if let token = observerToken {
+      DistributedNotificationCenter.default().removeObserver(token)
+      observerToken = nil
+    }
+  }
+
+  private var observerToken: NSObjectProtocol?
+}

--- a/PanicLock/SettingsManager.swift
+++ b/PanicLock/SettingsManager.swift
@@ -17,6 +17,7 @@ class SettingsManager: ObservableObject {
         static let iconStyle = "iconStyle"
         static let launchAtLogin = "launchAtLogin"
         static let confirmationSound = "confirmationSound"
+        static let lockOnClose = "lockOnClose"
     }
     
     @Published var keyboardShortcut: SavedKeyboardShortcut? {
@@ -48,7 +49,13 @@ class SettingsManager: ObservableObject {
             defaults.set(confirmationSound, forKey: Keys.confirmationSound)
         }
     }
-    
+
+    @Published var lockOnClose: Bool = false {
+        didSet {
+            defaults.set(lockOnClose, forKey: Keys.lockOnClose)
+        }
+    }
+
     private init() {
         // Register defaults so new users get launchAtLogin = true
         defaults.register(defaults: [
@@ -75,12 +82,16 @@ class SettingsManager: ObservableObject {
         
         // Load confirmation sound
         confirmationSound = defaults.bool(forKey: Keys.confirmationSound)
+
+        // Load lock on close
+        lockOnClose = defaults.bool(forKey: Keys.lockOnClose)
     }
-    
+
     func resetToDefaults() {
         keyboardShortcut = nil
         iconStyle = .shield
         launchAtLogin = true
         confirmationSound = false
+        lockOnClose = false
     }
 }


### PR DESCRIPTION
Hello!!

As discussed in #3 I thought I would open a PR. Because your app uses stronger assurances between the helper and the application (since you have a dev ID) I wasn't able to test. BioLocker uses self-signed and a weaker name based verification for the XPC calls and I didn't want to change that since this is stronger.

If anything breaks in testing let me know and I'll fix it.

Awesome work on PanicLock!!