### PR TITLE
fix: Correct keyCode mapping, fix dependabot, improve safety and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,6 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,15 @@ on:
 jobs:
   build:
     runs-on: macos-14
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.2'
 
       - name: Build
         run: |

--- a/PanicLock/AboutView.swift
+++ b/PanicLock/AboutView.swift
@@ -43,13 +43,15 @@ struct AboutView: View {
                 .padding(.horizontal, 40)
             
             // Website Link
-            Link(destination: URL(string: "https://paniclock.github.io/")!) {
-                HStack(spacing: 4) {
-                    Image(systemName: "globe")
-                    Text("paniclock.github.io")
+            if let url = URL(string: "https://paniclock.github.io/") {
+                Link(destination: url) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "globe")
+                        Text("paniclock.github.io")
+                    }
                 }
+                .font(.callout)
             }
-            .font(.callout)
             
             Spacer()
             

--- a/PanicLock/PreferencesView.swift
+++ b/PanicLock/PreferencesView.swift
@@ -58,7 +58,9 @@ struct PreferencesView: View {
                         .foregroundColor(.secondary)
                 }
                 
-                Link("View on GitHub", destination: URL(string: "https://github.com/paniclock/paniclock")!)
+                if let url = URL(string: "https://github.com/paniclock/paniclock") {
+                    Link("View on GitHub", destination: url)
+                }
             }
         }
         .formStyle(.grouped)
@@ -153,8 +155,8 @@ struct SavedKeyboardShortcut: Codable, Equatable {
             44: "/", 45: "N", 46: "M", 47: ".", 48: "⇥", 49: "Space",
             51: "⌫", 53: "⎋", 96: "F5", 97: "F6", 98: "F7", 99: "F3",
             100: "F8", 101: "F9", 103: "F11", 105: "F13", 107: "F14",
-            109: "F10", 111: "F12", 113: "F15", 118: "F4", 119: "F2",
-            120: "F1", 122: "F1", 123: "←", 124: "→", 125: "↓", 126: "↑"
+            109: "F10", 111: "F12", 113: "F15", 118: "F4",
+            120: "F2", 122: "F1", 123: "←", 124: "→", 125: "↓", 126: "↑"
         ]
         
         return keyCodeMap[keyCode] ?? "?"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/paniclock-logo-and-name-v1.png" alt="PanicLock" width="400">
 </p>
 
-PanicLock is macOS menu bar utility that instantly disables Touch ID and locks the screen with a single click or closing your laptop lid. 
+PanicLock is a macOS menu bar utility that instantly disables Touch ID and locks the screen with a single click or closing your laptop lid.
 
 PanicLock fills a gap macOS leaves open: there is no built-in way to instantly disable Touch ID when it matters. Biometrics are convenient day-to-day, and sometimes preferable when you need speed or want to avoid your password being observed. But in sensitive situations, law enforcement and border agents in many countries can compel a biometric unlock in ways they cannot with a password. PanicLock gives you a one-click menu bar button, a customizable hotkey, or an automatic lock-on-lid-close option that immediately disables Touch ID and locks your screen, restoring password-only protection without killing your session or shutting down.
 


### PR DESCRIPTION
## Summary

- **Fix keyboard shortcut display bug**: keyCode 120 was mapped to `"F1"` instead of `"F2"`, creating a duplicate with keyCode 122. Users pressing F2 would see "F1" in the shortcut display. Also removed incorrect keyCode 119 mapping (kVK_End shown as "F2").
- **Fix broken Dependabot config**: `package-ecosystem: ""` prevented Dependabot from running entirely. Set to `"github-actions"` to keep CI workflow dependencies updated.
- **Remove force-unwraps on `URL(string:)`**: Both `AboutView.swift` and `PreferencesView.swift` used `!` on URL creation. While unlikely to fail on static URLs, force-unwraps can crash the app and should be avoided.
- **Improve CI Xcode selection**: Replaced hardcoded `sudo xcode-select -s /Applications/Xcode_15.2.app` with the `maxim-lobanov/setup-xcode` action, which is more robust and self-documenting.
- **Fix README grammar**: Missing article "a" in opening sentence.

## Details

| Issue | Location | Fix |
|-------|----------|-----|
| Wrong F-key display | `PreferencesView.swift:155-157` | keyCode 120: "F1" → "F2", removed incorrect 119: "F2" |
| Dependabot not running | `.github/dependabot.yml` | `package-ecosystem: ""` → `"github-actions"` |
| Force-unwrap crash risk | `AboutView.swift:46`, `PreferencesView.swift:61` | `URL(string:...)!` → `if let url = URL(string:...)` |
| Fragile CI setup | `.github/workflows/build.yml` | `sudo xcode-select` → `maxim-lobanov/setup-xcode@v1` |
| Grammar | `README.md:5` | Added missing "a" article |

## Test plan

- [x] Code changes are syntactically correct
- [ ] Build succeeds in Xcode
- [ ] Keyboard shortcut display shows correct F-key labels
- [ ] CI workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)